### PR TITLE
Update semantic.py for Python compatibility

### DIFF
--- a/ngnk_lsp/semantic.py
+++ b/ngnk_lsp/semantic.py
@@ -6,7 +6,7 @@ from   importlib import resources
 def init():
     """Load K interface to semantic parsing."""
     # import semantic.k
-    with resources.as_file(resources.files().joinpath("semantic.k")) as semantick:
+    with resources.as_file(resources.files("ngnk_lsp").joinpath("semantic.k")) as semantick:
         k.Kx("\\l "+str(semantick), ())
 
     # load legend


### PR DESCRIPTION
The call to `resources.files()` fails on Python<3.12; versions before that require an argument to `files()`. It seems that, on 3.12, the call without an argument defaults to the name of the current package, which is `ngnk_lsp`, so I'm passing that in manually.